### PR TITLE
hades_li

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ function getBaseConfig () {
       'index': path.resolve('src', 'entry.js')
     },
     output: {
-      path: 'dist',
+      path: path.resolve(__dirname, 'dist')
     },
     module: {
       rules: [


### PR DESCRIPTION
* webpack最新版已经不支持原来的path写法。需要更新path地址采用绝对路径。