### PR TITLE
fix: use `weex.config.env` replace `WXEnvironment`

### DIFF
--- a/src/filters/index.js
+++ b/src/filters/index.js
@@ -7,10 +7,11 @@ export function host (url) {
 }
 
 export function https (url) {
-  if (WXEnvironment.platform === 'iOS' && typeof url === 'string') {
+  const env = weex.config.env || WXEnvironment
+  if (env.platform === 'iOS' && typeof url === 'string') {
     return url.replace(/^http\:/, 'https:')
   }
-  return ''
+  return url
 }
 
 export function timeAgo (time) {


### PR DESCRIPTION
`weex.config.env` is the new api, and  if not 'iOS' platform we should reutrn original url